### PR TITLE
fix(mailgun): make domain property mandatory

### DIFF
--- a/adonis-typings/mail.ts
+++ b/adonis-typings/mail.ts
@@ -412,7 +412,7 @@ declare module '@ioc:Adonis/Addons/Mail' {
     driver: 'mailgun'
     baseUrl: string
     key: string
-    domain?: string
+    domain: string
     oDkim?: boolean
   }
 

--- a/instructions.md
+++ b/instructions.md
@@ -29,6 +29,7 @@ You just need the Mailgun's private key in order to send emails using the Mailgu
 
 ```ts
 MAILGUN_API_KEY: Env.schema.string(),
+MAILGUN_DOMAIN: Env.schema.string(),
 ```
 
 ## Variables for the Sparkpost driver

--- a/instructions.ts
+++ b/instructions.ts
@@ -50,6 +50,7 @@ const DRIVER_ENV_VALUES = {
   },
   mailgun: {
     MAILGUN_API_KEY: '<mailgun-api-key>',
+    MAILGUN_DOMAIN: '<your-domain>',
   },
   sparkpost: {
     SPARKPOST_API_KEY: '<sparkpost-api-key>',

--- a/package.json
+++ b/package.json
@@ -70,8 +70,8 @@
     }
   },
   "peerDependencies": {
-    "@adonisjs/view": "^4.0.0",
-    "@adonisjs/core": "^5.0.5-canary-rc"
+    "@adonisjs/core": "^5.0.5-canary-rc",
+    "@adonisjs/view": "^4.0.0"
   },
   "dependencies": {
     "@poppinss/colors": "^2.1.0",

--- a/templates/config.txt
+++ b/templates/config.txt
@@ -89,11 +89,15 @@ const mailConfig: MailConfig = {
     |
 		| Uses Mailgun service for sending emails.
     |
+    | If you are using an EU domain. Ensure to change the baseUrl to hit the
+    | europe endpoint (https://api.eu.mailgun.net/v3).
+    |
     */
     mailgun: {
       driver: 'mailgun',
       baseUrl: 'https://api.mailgun.net/v3',
       key: Env.get('MAILGUN_API_KEY'),
+      domain: Env.get('MAILGUN_DOMAIN'),
     },
 
 		{{/mailgun}}


### PR DESCRIPTION
Hey! 👋 

This PR change the `MailgunConfig` to make the `domain` key mandatory.
It also add an information in the configuration for people using EU domain.