### PR TITLE
fix: Respect contracts directory defined in adonisjrc.json

### DIFF
--- a/instructions.ts
+++ b/instructions.ts
@@ -126,7 +126,8 @@ export default async function instructions(
   /**
    * Create the mail contracts file
    */
-  const contractsPath = app.makePath('contracts/mail.ts')
+  const contractsDir = app.directoriesMap.get('contracts') || 'contracts'
+  const contractsPath = app.makePath(`${contractsDir}/mail.ts`)
   const mailContract = new sink.files.MustacheFile(
     projectRoot,
     contractsPath,
@@ -141,7 +142,7 @@ export default async function instructions(
       sparkpost: mailDrivers.includes('sparkpost'),
     })
     .commit()
-  sink.logger.action('create').succeeded('contracts/mail.ts')
+  sink.logger.action('create').succeeded(`${contractsDir}/mail.ts`)
 
   /**
    * Setup .env file

--- a/instructions.ts
+++ b/instructions.ts
@@ -142,7 +142,7 @@ export default async function instructions(
       sparkpost: mailDrivers.includes('sparkpost'),
     })
     .commit()
-  sink.logger.action('create').succeeded(`${contractsDir}/mail.ts`)
+  sink.logger.action('create').succeeded(contractPath)
 
   /**
    * Setup .env file

--- a/instructions.ts
+++ b/instructions.ts
@@ -126,8 +126,7 @@ export default async function instructions(
   /**
    * Create the mail contracts file
    */
-  const contractsDirectory = app.directoriesMap.get('contracts') || 'contracts'
-  const contractPath = join(contractsDirectory, 'mail.ts')
+  const contractsDir = app.directoriesMap.get('contracts') || 'contracts'
   const contractsPath = app.makePath(`${contractsDir}/mail.ts`)
   const mailContract = new sink.files.MustacheFile(
     projectRoot,
@@ -143,7 +142,7 @@ export default async function instructions(
       sparkpost: mailDrivers.includes('sparkpost'),
     })
     .commit()
-  sink.logger.action('create').succeeded(contractPath)
+  sink.logger.action('create').succeeded(`${contractsDir}/mail.ts`)
 
   /**
    * Setup .env file

--- a/instructions.ts
+++ b/instructions.ts
@@ -126,7 +126,8 @@ export default async function instructions(
   /**
    * Create the mail contracts file
    */
-  const contractsDir = app.directoriesMap.get('contracts') || 'contracts'
+  const contractsDirectory = app.directoriesMap.get('contracts') || 'contracts'
+  const contractPath = join(contractsDirectory, 'mail.ts')
   const contractsPath = app.makePath(`${contractsDir}/mail.ts`)
   const mailContract = new sink.files.MustacheFile(
     projectRoot,


### PR DESCRIPTION
The `node ace configure @adonisjs/mail` ignores the defined `contracts` directory from the user inside `.adonisjrc.json`

This PR will respect the `contracts` directory defined by the user inside `.adonisjrc.json` and will fallback to default if not present.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/mail/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

@thetutlage point me to right direction for adding tests if necessary.
I can't find related tests for `node ace configure @adonisjs/mail`