### PR TITLE
fix: allow multiple addressed in replyTo

### DIFF
--- a/adonis-typings/mail.ts
+++ b/adonis-typings/mail.ts
@@ -127,7 +127,7 @@ declare module '@ioc:Adonis/Addons/Mail' {
     bcc?: RecipientNode[]
     messageId?: string
     subject?: string
-    replyTo?: RecipientNode
+    replyTo?: RecipientNode[]
     inReplyTo?: string
     references?: string[]
     encoding?: string

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "got": "^11.8.2",
     "ical-generator": "^3.4.1",
     "multi-part": "^3.0.0",
-    "nodemailer": "^6.7.3"
+    "nodemailer": "^6.7.8"
   },
   "repository": {
     "type": "git",

--- a/src/Message/index.ts
+++ b/src/Message/index.ts
@@ -108,7 +108,8 @@ export class Message implements MessageContract {
    * Define replyTo email and name
    */
   public replyTo(address: string, name?: string): this {
-    this.nodeMailerMessage.replyTo = this.getAddress(address, name)
+    this.nodeMailerMessage.replyTo = this.nodeMailerMessage.replyTo || []
+    this.nodeMailerMessage.replyTo.push(this.getAddress(address, name))
     return this
   }
 

--- a/test/message.spec.ts
+++ b/test/message.spec.ts
@@ -75,13 +75,15 @@ test.group('Message', () => {
   test('define replyTo', ({ assert }) => {
     const message = new Message()
     message.replyTo('foo@bar.com')
-    assert.deepEqual(message.toJSON().message, { replyTo: { address: 'foo@bar.com' } })
+    assert.deepEqual(message.toJSON().message, { replyTo: [{ address: 'foo@bar.com' }] })
   })
 
   test('define replyTo with name', ({ assert }) => {
     const message = new Message()
     message.replyTo('foo@bar.com', 'Foo')
-    assert.deepEqual(message.toJSON().message, { replyTo: { address: 'foo@bar.com', name: 'Foo' } })
+    assert.deepEqual(message.toJSON().message, {
+      replyTo: [{ address: 'foo@bar.com', name: 'Foo' }],
+    })
   })
 
   test('define in reply to messageId', ({ assert }) => {

--- a/test/message.spec.ts
+++ b/test/message.spec.ts
@@ -86,6 +86,18 @@ test.group('Message', () => {
     })
   })
 
+  test('define multiple replyTo with name', ({ assert }) => {
+    const message = new Message()
+    message.replyTo('foo@bar.com', 'Foo')
+    message.replyTo('foo@baz.com', 'FooBaz')
+    assert.deepEqual(message.toJSON().message, {
+      replyTo: [
+        { address: 'foo@bar.com', name: 'Foo' },
+        { address: 'foo@baz.com', name: 'FooBaz' },
+      ],
+    })
+  })
+
   test('define in reply to messageId', ({ assert }) => {
     const message = new Message()
     message.inReplyTo('1234')


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

As of now, `replyTo` accepts only a single address. On the next `replyTo` call, the previous value is overridden.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/mail/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
