### PR TITLE
fix: edge integration

### DIFF
--- a/providers/mail_provider.ts
+++ b/providers/mail_provider.ts
@@ -38,7 +38,11 @@ export default class MailProvider {
   protected async defineTemplateEngine() {
     if (this.app.usingEdgeJS) {
       const edge = await import('edge.js')
-      Message.templateEngine = edge.default
+      Message.templateEngine = {
+        render(templatePath, helpers, data) {
+          return edge.default.share(helpers).render(templatePath, data)
+        },
+      }
     }
   }
 

--- a/tests/integration/mail_provider.spec.ts
+++ b/tests/integration/mail_provider.spec.ts
@@ -81,34 +81,6 @@ test.group('Mail Provider', () => {
     await app.container.make('mail.manager')
   }).throws('Invalid "config/mail.ts" file. Make sure you are using the "defineConfig" method')
 
-  test('share edge template engine with Message class', async ({ assert }) => {
-    const ignitor = new IgnitorFactory()
-      .merge({
-        rcFileContents: {
-          providers: [
-            () => import('@adonisjs/core/providers/edge_provider'),
-            () => import('../../providers/mail_provider.js'),
-          ],
-        },
-      })
-      .withCoreConfig()
-      .withCoreProviders()
-      .merge({
-        config: {
-          mail: {},
-        },
-      })
-      .create(BASE_URL, {
-        importer: IMPORTER,
-      })
-
-    const app = ignitor.createApp('web')
-    await app.init()
-    await app.boot()
-
-    assert.strictEqual(Message.templateEngine, edge)
-  })
-
   test('correctly share helpers and view data with edge', async ({ assert }) => {
     const ignitor = new IgnitorFactory()
       .merge({


### PR DESCRIPTION
Doing something like that was not working before this PR : 

```ts
await mail.send((message) => {
  message.htmlView('my_template, { data })
})
 ```

Because at the provider level, Edge was not correctly registered as the mailer template engine