### PR TITLE
fix(transports/brevo): brevo allow only one replyTo address

### DIFF
--- a/src/transports/brevo.ts
+++ b/src/transports/brevo.ts
@@ -81,7 +81,7 @@ class NodeMailerTransport implements Transport {
     }
 
     if (mail.data.replyTo) {
-      payload.replyTo = this.#formatAddresses(mail.data.replyTo)
+      payload.replyTo = this.#formatAddresses(mail.data.replyTo)[0]
     }
 
     if (mail.data.cc) {


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Brevo allow only one replyTo address as a object not a array object

Not valid:

```sh
curl -X POST "https://api.brevo.com/v3/smtp/email" \
-H "accept: application/json" \
-H "api-key: xkeysib-dunno" \
-H "Content-Type: application/json" \
-d '{
  "sender": {
    "name": "Sender Name",
    "email": "no-reply@yes.com"
  },
  "to": [
    {
      "email": "test@test.com",
      "name": "Recipient Name"
    }
  ],
  "replyTo": [{
    "email": "reply-me@yes.com",
    "name": "Reply To Name"
  }],
  "subject": "Your Subject Here",
  "htmlContent": "<html><body><p>Your email content here.</p></body></html>"
}'
```

Error: `{"code":"invalid_parameter","message":"replyTo is not valid"}`

If you don't pass a array but an object directly it works perfectly

```bash
curl -X POST "https://api.brevo.com/v3/smtp/email" \
-H "accept: application/json" \
-H "api-key: xkeysib-dunno" \
-H "Content-Type: application/json" \
-d '{
  "sender": {
    "name": "Sender Name",
    "email": "no-reply@yes.com"
  },
  "to": [
    {
      "email": "test@test.com",
      "name": "Recipient Name"
    }
  ],
  "replyTo": {
    "email": "reply-me@yes.com",
    "name": "Reply To Name"
  },
  "subject": "Your Subject Here",
  "htmlContent": "<html><body><p>Your email content here.</p></body></html>"
}'
```
