### PR TITLE
Fix brevo transport, API allows onyl one replyTo address, not an array

### DIFF
--- a/src/transports/brevo.ts
+++ b/src/transports/brevo.ts
@@ -81,7 +81,9 @@ class NodeMailerTransport implements Transport {
     }
 
     if (mail.data.replyTo) {
-      payload.replyTo = this.#formatAddresses(mail.data.replyTo)
+      payload.replyTo = this.#formatAddress(
+        Array.isArray(mail.data.replyTo) ? mail.data.replyTo[0] : mail.data.replyTo
+      )
     }
 
     if (mail.data.cc) {


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
#105 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Brevo allow only one replyTo address as a object not a array object

Not valid:
```bash
curl -X POST "https://api.brevo.com/v3/smtp/email" \
-H "accept: application/json" \
-H "api-key: xkeysib-dunno" \
-H "Content-Type: application/json" \
-d '{
  "sender": {
    "name": "Sender Name",
    "email": "no-reply@yes.com"
  },
  "to": [
    {
      "email": "test@test.com",
      "name": "Recipient Name"
    }
  ],
  "replyTo": [{
    "email": "reply-me@yes.com",
    "name": "Reply To Name"
  }],
  "subject": "Your Subject Here",
  "htmlContent": "<html><body><p>Your email content here.</p></body></html>"
}'
```
Error: `{"code":"invalid_parameter","message":"replyTo is not valid"}`

If you don't pass a array but an object directly it works perfectly
```bash
❓ Type of change
 🐞 Bug fix (a non-breaking change that fixes an issue)
 👌 Enhancement (improving an existing functionality like performance)
 ✨ New feature (a non-breaking change that adds functionality)
 ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
📚 Description
Brevo allow only one replyTo address as a object not a array object

Not valid:

curl -X POST "https://api.brevo.com/v3/smtp/email" \
-H "accept: application/json" \
-H "api-key: xkeysib-dunno" \
-H "Content-Type: application/json" \
-d '{
  "sender": {
    "name": "Sender Name",
    "email": "no-reply@yes.com"
  },
  "to": [
    {
      "email": "test@test.com",
      "name": "Recipient Name"
    }
  ],
  "replyTo": [{
    "email": "reply-me@yes.com",
    "name": "Reply To Name"
  }],
  "subject": "Your Subject Here",
  "htmlContent": "<html><body><p>Your email content here.</p></body></html>"
}'
Error: {"code":"invalid_parameter","message":"replyTo is not valid"}

If you don't pass a array but an object directly it works perfectly

curl -X POST "https://api.brevo.com/v3/smtp/email" \
-H "accept: application/json" \
-H "api-key: xkeysib-dunno" \
-H "Content-Type: application/json" \
-d '{
  "sender": {
    "name": "Sender Name",
    "email": "no-reply@yes.com"
  },
  "to": [
    {
      "email": "test@test.com",
      "name": "Recipient Name"
    }
  ],
  "replyTo": {
    "email": "reply-me@yes.com",
    "name": "Reply To Name"
  },
  "subject": "Your Subject Here",
  "htmlContent": "<html><body><p>Your email content here.</p></body></html>"
}'
```

This is the exact same PR (almost) as #104

Brevo documentation [here](https://developers.brevo.com/reference/sendtransacemail)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
