### PR TITLE
chore: use "mail" wording instead of "notification"

### DIFF
--- a/commands/make_mail.ts
+++ b/commands/make_mail.ts
@@ -38,7 +38,7 @@ export default class MakeMail extends BaseCommand {
     const codemods = await this.createCodemods()
     await codemods.makeUsingStub(stubsRoot, 'make/mail/main.stub', {
       flags: this.parsed.flags,
-      intent: this.intent || 'notification',
+      intent: this.intent || 'mail',
       entity: this.app.generators.createEntity(this.name),
     })
   }

--- a/tests/integration/commands/make_mail.spec.ts
+++ b/tests/integration/commands/make_mail.spec.ts
@@ -20,14 +20,14 @@ test.group('MakeMail', () => {
     const command = await ace.create(MakeMail, ['email_verification'])
     await command.exec()
 
-    command.assertLog('green(DONE:)    create app/mails/email_verification_notification.ts')
+    command.assertLog('green(DONE:)    create app/mails/email_verification_mail.ts')
     await assert.fileContains(
-      'app/mails/email_verification_notification.ts',
+      'app/mails/email_verification_mail.ts',
       `import { BaseMail } from '@adonisjs/mail'`
     )
     await assert.fileContains(
-      'app/mails/email_verification_notification.ts',
-      `export default class EmailVerificationNotification extends BaseMail {`
+      'app/mails/email_verification_mail.ts',
+      `export default class EmailVerificationMail extends BaseMail {`
     )
   })
 

--- a/tests/unit/fake_mailer/mails.spec.ts
+++ b/tests/unit/fake_mailer/mails.spec.ts
@@ -100,7 +100,7 @@ test.group('Fake mailer | mails | send', (group) => {
         this.message.to('bar@baz.com')
       }
     }
-    class PaymentDueNotification extends BaseMail {
+    class PaymentDueMail extends BaseMail {
       from: string = 'foo@bar.com'
       subject: string = 'Clear your dues'
 
@@ -111,10 +111,10 @@ test.group('Fake mailer | mails | send', (group) => {
 
     await mailer.send(new VerifyEmail())
     await mailer.send(new VerifyEmail())
-    await mailer.send(new PaymentDueNotification())
+    await mailer.send(new PaymentDueMail())
 
     mails.assertSentCount(VerifyEmail, 2)
-    mails.assertSentCount(PaymentDueNotification, 1)
+    mails.assertSentCount(PaymentDueMail, 1)
     mails.assertSentCount(3)
 
     assert.throws(() => {
@@ -138,7 +138,7 @@ test.group('Fake mailer | mails | send', (group) => {
         this.message.to('bar@baz.com')
       }
     }
-    class PaymentDueNotification extends BaseMail {
+    class PaymentDueMail extends BaseMail {
       from: string = 'foo@bar.com'
       subject: string = 'Clear your dues'
 
@@ -151,7 +151,7 @@ test.group('Fake mailer | mails | send', (group) => {
 
     await mailer.send(new VerifyEmail())
     await mailer.send(new VerifyEmail())
-    await mailer.send(new PaymentDueNotification())
+    await mailer.send(new PaymentDueMail())
 
     assert.throws(() => {
       return mails.assertNoneSent()
@@ -310,7 +310,7 @@ test.group('Fake mailer | mails | sendLater', (group) => {
         this.message.to('bar@baz.com')
       }
     }
-    class PaymentDueNotification extends BaseMail {
+    class PaymentDueMail extends BaseMail {
       from: string = 'foo@bar.com'
       subject: string = 'Clear your dues'
 
@@ -321,10 +321,10 @@ test.group('Fake mailer | mails | sendLater', (group) => {
 
     await mailer.sendLater(new VerifyEmail())
     await mailer.sendLater(new VerifyEmail())
-    await mailer.sendLater(new PaymentDueNotification())
+    await mailer.sendLater(new PaymentDueMail())
 
     mails.assertQueuedCount(VerifyEmail, 2)
-    mails.assertQueuedCount(PaymentDueNotification, 1)
+    mails.assertQueuedCount(PaymentDueMail, 1)
     mails.assertQueuedCount(3)
 
     assert.throws(() => {
@@ -348,7 +348,7 @@ test.group('Fake mailer | mails | sendLater', (group) => {
         this.message.to('bar@baz.com')
       }
     }
-    class PaymentDueNotification extends BaseMail {
+    class PaymentDueMail extends BaseMail {
       from: string = 'foo@bar.com'
       subject: string = 'Clear your dues'
 
@@ -361,7 +361,7 @@ test.group('Fake mailer | mails | sendLater', (group) => {
 
     await mailer.sendLater(new VerifyEmail())
     await mailer.sendLater(new VerifyEmail())
-    await mailer.sendLater(new PaymentDueNotification())
+    await mailer.sendLater(new PaymentDueMail())
 
     assert.throws(() => {
       return mails.assertNoneQueued()


### PR DESCRIPTION
Using "mail" wording instead of "notifications" since otherwise it will conflict with our future Notification package which also use the same term