### PR TITLE
fix(configure): use number schema for SMTP_PORT and update tests

### DIFF
--- a/configure.ts
+++ b/configure.ts
@@ -115,7 +115,8 @@ export async function configure(command: Configure) {
     variables: transports.reduce<Record<string, string>>(
       (result, transport) => {
         ENV_VARIABLES[transport as keyof typeof ENV_VARIABLES].forEach((envVariable) => {
-          result[envVariable] = 'Env.schema.string()'
+          result[envVariable] =
+            `Env.schema.${envVariable === 'SMTP_PORT' ? 'number()' : 'string()'}`
         })
         return result
       },

--- a/tests/integration/configure.spec.ts
+++ b/tests/integration/configure.spec.ts
@@ -51,6 +51,7 @@ test.group('Configure', (group) => {
       '../../index.js',
       '--transports=sparkpost',
       '--transports=resend',
+      '--transports=smtp',
     ])
     await command.exec()
 
@@ -76,17 +77,40 @@ test.group('Configure', (group) => {
       baseUrl: 'https://api.resend.com',
     }),`
     )
+    await assert.fileContains(
+      'config/mail.ts',
+      `
+    smtp: transports.smtp({
+      host: env.get('SMTP_HOST'),
+      port: env.get('SMTP_PORT'),
+			/**
+       * Uncomment the auth block if your SMTP
+       * server needs authentication
+       */
+      /* auth: {
+        type: 'login',
+        user: env.get('SMTP_USERNAME'),
+        pass: env.get('SMTP_PASSWORD'),
+      }, */
+    }),`
+    )
+
     await assert.fileContains('.env', 'SPARKPOST_API_KEY')
     await assert.fileContains('.env', 'RESEND_API_KEY')
+    await assert.fileContains('.env', 'SMTP_HOST')
+    await assert.fileContains('.env', 'SMTP_PORT')
     await assert.fileContains('.env', 'MAIL_MAILER')
     await assert.fileContains('.env', 'MAIL_FROM_NAME')
     await assert.fileContains('.env', 'MAIL_FROM_ADDRESS')
 
     await assert.fileContains('start/env.ts', 'SPARKPOST_API_KEY: Env.schema.string()')
     await assert.fileContains('start/env.ts', 'RESEND_API_KEY: Env.schema.string()')
+    await assert.fileContains('start/env.ts', 'SMTP_HOST: Env.schema.string()')
+    await assert.fileContains('start/env.ts', 'SMTP_PORT: Env.schema.number()')
+
     await assert.fileContains(
       'start/env.ts',
-      `MAIL_MAILER: Env.schema.enum(['sparkpost', 'resend'] as const)`
+      `MAIL_MAILER: Env.schema.enum(['sparkpost', 'resend', 'smtp'] as const)`
     )
     await assert.fileContains('start/env.ts', 'MAIL_FROM_NAME: Env.schema.string()')
     await assert.fileContains('start/env.ts', 'MAIL_FROM_ADDRESS: Env.schema.string()')


### PR DESCRIPTION
Ensure SMTP_PORT is validated using Env.schema.number() instead of string. Also updates configure.spec.ts to cover the correct behavior.

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixes #118

Ensure `SMTP_PORT` is validated as a number instead of a string during configure.

## ✅ Changes

- Use `Env.schema.number()` for `SMTP_PORT`
- Keep other env variables as strings
- Update `configure.spec.ts` to cover this behavior

## 🧪 Result

Correct typing for SMTP port and improved test coverage.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
