### PR TITLE
fix(types): add SMTP pool options to SMTPConfig type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ import { type AsyncOrSync } from '@adonisjs/core/types/common'
 import type { SESv2ClientConfig } from '@aws-sdk/client-sesv2'
 import type MimeNode from 'nodemailer/lib/mime-node/index.js'
 import type { Options as SMTPConnectionOptions } from 'nodemailer/lib/smtp-connection/index.js'
+import type { Options as SMTPPoolOptions } from 'nodemailer/lib/smtp-pool/index.js'
 
 import type { Message } from './message.js'
 import type { BaseMail } from './base_mail.js'
@@ -384,7 +385,10 @@ export type SMTPConfig = (
    * Authentication
    */
   auth?: SMTPSimpleAuth | SMTPOauth2
-} & SMTPConnectionOptions
+} & SMTPConnectionOptions &
+  Partial<
+    Pick<SMTPPoolOptions, 'pool' | 'maxConnections' | 'maxMessages' | 'rateDelta' | 'rateLimit'>
+  >
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/unit/define_config.spec.ts
+++ b/tests/unit/define_config.spec.ts
@@ -30,6 +30,18 @@ test.group('Define config', () => {
     assert.instanceOf(smtpFactory(), SMTPTransport)
     expectTypeOf(smtpFactory()).toMatchTypeOf<SMTPTransport>()
 
+    const smtpPoolProvider = transports.smtp({
+      host: '',
+      pool: true,
+      maxConnections: 5,
+      maxMessages: 100,
+      rateDelta: 1000,
+      rateLimit: 10,
+    })
+    const smtpPoolFactory = await smtpPoolProvider.resolver(app)
+    assert.instanceOf(smtpPoolFactory(), SMTPTransport)
+    expectTypeOf(smtpPoolFactory()).toMatchTypeOf<SMTPTransport>()
+
     const sesProvider = transports.ses({
       credentials: {
         accessKeyId: process.env.AWS_ACCESS_KEY_ID!,


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`SMTPConfig` type was missing pool-related properties (`pool`, `maxConnections`, `maxMessages`, `rateDelta`, `rateLimit`) from nodemailer's `SMTPPool.Options`, causing TypeScript errors when configuring SMTP with connection pooling in AdonisJS v7.

These options work at runtime since nodemailer detects `pool: true` and switches to `SMTPPool` transport, but the type definition didn't include them — forcing users to use `@ts-ignore`.

Fix uses `Partial<Pick<SMTPPool.Options, ...>>` to import only the 5 pool-specific fields from nodemailer's own types, keeping them optional and in sync with nodemailer.

Resolves #121


### 📝 Checklist

- [x ] I have linked an issue or discussion. https://github.com/adonisjs/mail/issues/121
- [ ] I have updated the documentation accordingly.