### PR TITLE
fix(release): pass secrets to checks job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: read
     uses: ./.github/workflows/checks.yml
+    secrets: inherit
 
   release:
     needs: checks


### PR DESCRIPTION
Regression fix for #128. That PR dropped `secrets: inherit` from the `checks` job in `release.yml`. Since the reusable `checks.yml` uses integration-test secrets (`RESEND_API_KEY`, `AWS_SECRET_ACCESS_KEY`, etc.) the release that ran after merging #128 failed with empty env vars. This restores the previous `secrets: inherit` line.

Re-running the release workflow after merge should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)